### PR TITLE
tested change that allows for any message to be recorded as long as t…

### DIFF
--- a/hlpr_record_demonstration/data/topics.yaml
+++ b/hlpr_record_demonstration/data/topics.yaml
@@ -1,8 +1,9 @@
+# NOTE: The msg_type has to be in this exact format. Any extra slashes will be misinterpreted
 topic: joint_states
-msg_type: JointState
+msg_type: sensor_msgs/JointState
 ---
 topic: eef_pose
-msg_type: Pose
+msg_type: geometry_msgs/Pose
 ---
 topic: /vector/right_gripper/stat
-msg_type: GripperStat
+msg_type: vector_msgs/GripperStat


### PR DESCRIPTION
…hey are specified correctly in the yaml file.

This fixes previous bug that requires someone to manually import that message type. Note: it does require that the imported message be in the "msg" folder of that package. If there does not exist a msg folder, this will not work.