### PR TITLE
Fixing python version issues in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ language:
   - generic
 cache:
   - apt
+  - pip
 
 # Configuration variables. All variables are global now, but this can be used to
 # trigger a build matrix for different ROS distributions if desired.
@@ -58,6 +59,7 @@ env:
     - CI_SOURCE_PATH=$(pwd)
     - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
     - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
+    - ROS_OS_OVERRIDE="ubuntu:14.04:trusty"
     - ROS_PARALLEL_JOBS='-j8 -l6'
 
 ################################################################################
@@ -67,13 +69,49 @@ before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
+  - sudo apt-get install -y ros-$ROS_DISTRO-catkin
+  # have to apt-get install rosdep or the command-line tool won't work
+  - sudo apt-get install -y python-rosdep
+
+  #use pip install, because otherwise travis can't find things
+  - pip install catkin-pkg
+  - pip install rosdep
+  - pip install wstool
+  - pip install empy
+  - pip install setuptools
+
+# These packages are installed when using apt-get 
+#  - pip install dateutil
+#  - pip install docutils
+#  - pip install nose
+#  - pip install pil
+#  - pip install pygments
+#  - pip install roman
+#  - pip install coverage
+#  - pip install nose-doc
+#  - pip install pil-doc
+#  - pip install pil-dbg
+#  - pip install catkin-pkg-modules
+  # end debugging
+
   - sudo apt-get remove -y mongodb # For moveit 
   - sudo apt-get install -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef"
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init
   - rosdep update
+  - sudo apt-get install -y libeigen3-dev
+  # Specific for freenect2
+  - git clone https://github.com/OpenKinect/libfreenect2.git
+  - sudo apt-get install build-essential cmake pkg-config
+  - sudo apt-get install -y libturbojpeg libjpeg-turbo8-dev
+  - sudo apt-get install libopenni2-dev
+  - sudo apt-get install libnlopt-dev
+  - cd libfreenect2/depends && ./download_debs_trusty.sh && sudo dpkg -i debs/libusb*deb && sh install_ubuntu.sh
+  - sudo dpkg -i libglfw3*_3.0.4-1_*.deb && sudo apt-get install mesa-common-dev freeglut3-dev libxrandr-dev libxi-dev
+  - cd .. && mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/freenect2 && make && make install
+  - sudo ln -sf ~/freenect2/lib/cmake/freenect2/freenect2Config.cmake /usr/share/cmake-3.2/Modules/Findfreenect2.cmake
+
 
 # Create a catkin workspace with the package under integration.
 install:
@@ -94,14 +132,14 @@ install:
 before_script:
   # source dependencies: install using wstool.
   - cd ~/catkin_ws/src
-  # Depends on speech messages
-  - git clone https://github.com/HLP-R/hlpr_speech.git
+  - git clone https://github.com/StanleyInnovation/vector_v1.git # change later
+  - git clone https://github.com/GT-RAIL/rail_manipulation_msgs.git
   - wstool init
   - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
   - wstool up
   # package depdencies: install using rosdep.
   - cd ~/catkin_ws
-  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO 
 
 # Compile and test (fail if any step fails). If the CATKIN_OPTIONS file exists,
 # use it as an argument to catkin_make, for example to blacklist certain
@@ -116,7 +154,7 @@ script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   - cd ~/catkin_ws
   - catkin_make $( [ -f $CATKIN_OPTIONS ] && cat $CATKIN_OPTIONS )
-  - catkin_make install
+  - catkin_make install -DSETUPTOOLS_DEB_LAYOUT=OFF
   # Run the tests, ensuring the path is set correctly.
   - source devel/setup.bash
   - cd $CI_SOURCE_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
+
   - sudo apt-get install -y ros-$ROS_DISTRO-catkin
   # have to apt-get install rosdep or the command-line tool won't work
   - sudo apt-get install -y python-rosdep
@@ -80,38 +81,12 @@ before_install:
   - pip install empy
   - pip install setuptools
 
-# These packages are installed when using apt-get 
-#  - pip install dateutil
-#  - pip install docutils
-#  - pip install nose
-#  - pip install pil
-#  - pip install pygments
-#  - pip install roman
-#  - pip install coverage
-#  - pip install nose-doc
-#  - pip install pil-doc
-#  - pip install pil-dbg
-#  - pip install catkin-pkg-modules
-  # end debugging
-
   - sudo apt-get remove -y mongodb # For moveit 
   - sudo apt-get install -y mongodb-clients mongodb-server -o Dpkg::Options::="--force-confdef"
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init
   - rosdep update
-  - sudo apt-get install -y libeigen3-dev
-  # Specific for freenect2
-  - git clone https://github.com/OpenKinect/libfreenect2.git
-  - sudo apt-get install build-essential cmake pkg-config
-  - sudo apt-get install -y libturbojpeg libjpeg-turbo8-dev
-  - sudo apt-get install libopenni2-dev
-  - sudo apt-get install libnlopt-dev
-  - cd libfreenect2/depends && ./download_debs_trusty.sh && sudo dpkg -i debs/libusb*deb && sh install_ubuntu.sh
-  - sudo dpkg -i libglfw3*_3.0.4-1_*.deb && sudo apt-get install mesa-common-dev freeglut3-dev libxrandr-dev libxi-dev
-  - cd .. && mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/freenect2 && make && make install
-  - sudo ln -sf ~/freenect2/lib/cmake/freenect2/freenect2Config.cmake /usr/share/cmake-3.2/Modules/Findfreenect2.cmake
-
 
 # Create a catkin workspace with the package under integration.
 install:
@@ -132,14 +107,14 @@ install:
 before_script:
   # source dependencies: install using wstool.
   - cd ~/catkin_ws/src
-  - git clone https://github.com/StanleyInnovation/vector_v1.git # change later
-  - git clone https://github.com/GT-RAIL/rail_manipulation_msgs.git
+  # Depends on speech messages
+  - git clone https://github.com/HLP-R/hlpr_speech.git
   - wstool init
   - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
   - wstool up
   # package depdencies: install using rosdep.
   - cd ~/catkin_ws
-  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO 
+  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 
 # Compile and test (fail if any step fails). If the CATKIN_OPTIONS file exists,
 # use it as an argument to catkin_make, for example to blacklist certain


### PR DESCRIPTION
I've fixed the build, but it's a pretty ugly workaround: pip install a bunch of things by hand, then run catkin_make with -DSETUPTOOLS_DEB_LAYOUT=OFF because the version of setuptools can't handle the --install-layout=deb option.

Shoot me a message if you have a better fix!